### PR TITLE
Convert html input to string before processing

### DIFF
--- a/lib/plain_david/action_mailer_extensions.rb
+++ b/lib/plain_david/action_mailer_extensions.rb
@@ -46,7 +46,7 @@ module PlainDavid
     end
 
     def generate_text_body(html)
-      PlainDavid.current_strategy.new(html).convert!
+      PlainDavid.current_strategy.new(html.to_str).convert!
     end
   end
 end


### PR DESCRIPTION
This sanitization step works around an issue with safe buffers in recent versions of Rails. The bug breaks $\* variables in the context of gsub blocks, resulting in all entities being replaced with the empty string (''). See https://github.com/rails/rails/issues/1555 for more details.
